### PR TITLE
fix: stub GEWIS photo API in test

### DIFF
--- a/apps/aurora-core/integration-test/modules/carousel-poster.spec.ts
+++ b/apps/aurora-core/integration-test/modules/carousel-poster.spec.ts
@@ -1,4 +1,5 @@
-import { describe, beforeAll, it, expect } from 'vitest';
+import { describe, beforeAll, it, expect, vi } from 'vitest';
+import axios, { AxiosError, type AxiosResponse } from 'axios';
 import { TestEnvironment, type TestApp } from '../shared/test-app';
 import { expectApiError, expectValidationError } from '../shared/response-matchers';
 
@@ -247,6 +248,11 @@ describe('POST /api/handler/screen/poster/carousel/photo', () => {
   });
 
   it('returns 403 when GEWIS API rejects unauthenticated request', async () => {
+    // ARRANGE
+    const rejection = new AxiosError('Forbidden');
+    rejection.response = { status: 403, statusText: 'Forbidden' } as AxiosResponse;
+    const axiosSpy = vi.spyOn(axios, 'get').mockRejectedValue(rejection);
+
     // ACT
     const res = await testApp.authorizedAgent
       .post('/api/handler/screen/poster/carousel/photo')
@@ -254,6 +260,7 @@ describe('POST /api/handler/screen/poster/carousel/photo', () => {
 
     // ASSERT
     expect(res.status).toBe(403);
+    axiosSpy.mockRestore();
   });
 });
 


### PR DESCRIPTION
Fix tests failing when the GEWIS.nl API is down.

<!-- Provide a general summary of your changes in the title above. -->

# Description
Currently one of the tests tries to call to the actual GEWIS.nl photo API which makes the test fail when that site is offline. This is unwanted as the tests should not be dependent on other parties. The test now mocks the endpoint instead

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
- CI/CD _(Changes to the CI/CD configuration)_
