### PR TITLE
feat: reset handlers after mode ends

### DIFF
--- a/apps/aurora-core/integration-test/modules/mode.spec.ts
+++ b/apps/aurora-core/integration-test/modules/mode.spec.ts
@@ -49,7 +49,7 @@ describe('POST /api/modes/centurion', () => {
     expectValidationError(res, 400);
   });
 
-  it('returns 500 with admin auth (ModeManager not initialized)', async () => {
+  it('returns 404 when the tape does not exist', async () => {
     // ACT
     const res = await testApp.authorizedAgent.post('/api/modes/centurion').send({
       lightsGroupIds: [],
@@ -57,6 +57,20 @@ describe('POST /api/modes/centurion', () => {
       audioIds: [],
       centurionName: 'test',
       centurionArtist: 'test',
+    });
+
+    // ASSERT
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 500 with admin auth (ModeManager not initialized)', async () => {
+    // ACT
+    const res = await testApp.authorizedAgent.post('/api/modes/centurion').send({
+      lightsGroupIds: [],
+      screenIds: [],
+      audioIds: [],
+      centurionName: 'Totale EscalaTIEN',
+      centurionArtist: 'Gebroeders Scooter',
     });
 
     // ASSERT

--- a/apps/aurora-core/src/modules/modes/base-mode.ts
+++ b/apps/aurora-core/src/modules/modes/base-mode.ts
@@ -1,5 +1,6 @@
 import { LightsGroup } from '../lights/entities';
 import { Audio, Screen } from '../root/entities';
+import SubscribeEntity from '../root/entities/subscribe-entity';
 import HandlerManager from '../root/handler-manager';
 import BaseLightsHandler from '../handlers/base-lights-handler';
 import BaseAudioHandler from '../handlers/base-audio-handler';
@@ -18,6 +19,8 @@ export default abstract class BaseMode<
 
   protected audioHandler: V;
 
+  private previousHandlers = new Map<SubscribeEntity, string>();
+
   /**
    * Assign the given entities to the given handlers
    */
@@ -30,12 +33,15 @@ export default abstract class BaseMode<
     protected readonly audioHandlerName: string,
   ) {
     _lights.forEach((lightsGroup) => {
+      this.cachePreviousHandler(lightsGroup);
       this.handlerManager.registerHandler(lightsGroup, lightsHandlerName);
     });
     _screens.forEach((screen) => {
+      this.cachePreviousHandler(screen);
       this.handlerManager.registerHandler(screen, screenHandlerName);
     });
     _audios.forEach((audio) => {
+      this.cachePreviousHandler(audio);
       this.handlerManager.registerHandler(audio, audioHandlerName);
     });
 
@@ -59,21 +65,34 @@ export default abstract class BaseMode<
   }
 
   /**
+   * Remember which handler an entity was on, so it can be given back on destroy.
+   * Entities on no handler are not recorded, and stay unassigned on destroy.
+   */
+  private cachePreviousHandler<T extends SubscribeEntity>(entity: T): void {
+    const currentHandler = this.handlerManager.getHandler(entity);
+    if (currentHandler) {
+      this.previousHandlers.set(entity, currentHandler);
+    }
+  }
+
+  /**
+   * Return the entities to the handler they were on before this mode claimed
+   * them, or to no handler if they were not on one.
+   */
+  private releaseEntities<T extends SubscribeEntity>(entities: T[], handlerName: string): void {
+    entities.forEach((entity) => {
+      if (this.handlerManager.getHandler(entity) !== handlerName) return;
+      this.handlerManager.registerHandler(entity, this.previousHandlers.get(entity) ?? '');
+    });
+  }
+
+  /**
    * Unregister all listeners from the handler corresponding to this mode.
    */
   destroy(): void {
-    this._lights.forEach((lightsGroup) => {
-      if (this.handlerManager.getHandler(lightsGroup) !== this.lightsHandlerName) return;
-      this.handlerManager.registerHandler(lightsGroup, '');
-    });
-    this._screens.forEach((screen) => {
-      if (this.handlerManager.getHandler(screen) !== this.screenHandlerName) return;
-      this.handlerManager.registerHandler(screen, '');
-    });
-    this._audios.forEach((audio) => {
-      if (this.handlerManager.getHandler(audio) !== this.audioHandlerName) return;
-      this.handlerManager.registerHandler(audio, '');
-    });
+    this.releaseEntities(this._lights, this.lightsHandlerName);
+    this.releaseEntities(this._screens, this.screenHandlerName);
+    this.releaseEntities(this._audios, this.audioHandlerName);
   }
 
   // Getter function, as we might add more entities to the lightsHandler later

--- a/apps/aurora-core/src/modules/modes/mode-controller.ts
+++ b/apps/aurora-core/src/modules/modes/mode-controller.ts
@@ -81,10 +81,6 @@ export class ModeController extends Controller {
   ): Promise<string> {
     logger.audit(req.user, `Enable Centurion mode with tape "${params.centurionName}".`);
 
-    const { lights, screens, audios } = await this.mapBodyToEntities(params);
-
-    const centurionMode = new CenturionMode(lights, screens, audios);
-    await centurionMode.initialize(this.modeManager.musicEmitter);
     const tape = tapes.find((t) => {
       return t.name === params.centurionName && t.artist === params.centurionArtist;
     });
@@ -92,8 +88,15 @@ export class ModeController extends Controller {
       this.setStatus(404);
       return 'Centurion tape not found.';
     }
-    centurionMode.loadTape(tape);
-    this.modeManager.enableMode(CenturionMode, centurionMode, 'centurion');
+
+    const { lights, screens, audios } = await this.mapBodyToEntities(params);
+
+    await this.modeManager.enableMode(CenturionMode, 'centurion', async () => {
+      const centurionMode = new CenturionMode(lights, screens, audios);
+      await centurionMode.initialize(this.modeManager.musicEmitter);
+      centurionMode.loadTape(tape);
+      return centurionMode;
+    });
 
     this.setStatus(204);
     return '';
@@ -125,9 +128,11 @@ export class ModeController extends Controller {
 
     const { lights, screens, audios } = await this.mapBodyToEntities(params);
 
-    const timeTrailRaceMode = new TimeTrailRaceMode(lights, screens, audios);
-    timeTrailRaceMode.initialize(this.modeManager.backofficeSyncEmitter, params.sessionName);
-    this.modeManager.enableMode(TimeTrailRaceMode, timeTrailRaceMode, 'time-trail-racing');
+    await this.modeManager.enableMode(TimeTrailRaceMode, 'time-trail-racing', () => {
+      const timeTrailRaceMode = new TimeTrailRaceMode(lights, screens, audios);
+      timeTrailRaceMode.initialize(this.modeManager.backofficeSyncEmitter, params.sessionName);
+      return timeTrailRaceMode;
+    });
 
     this.setStatus(204);
     return '';

--- a/apps/aurora-core/src/modules/modes/mode-manager.ts
+++ b/apps/aurora-core/src/modules/modes/mode-manager.ts
@@ -25,16 +25,19 @@ export default class ModeManager {
     this.initialized = true;
   }
 
-  public enableMode(
+  public async enableMode<T extends BaseMode<any, any, any>>(
     modeClass: typeof BaseMode<any, any, any>,
-    mode: BaseMode<any, any, any>,
     name: string,
-  ) {
+    createMode: () => T | Promise<T>,
+  ): Promise<T> {
     // If an instance of this mode already exist, destroy it before creating a new one
     if (this.modes.has(modeClass)) this.disableMode(modeClass);
 
+    const mode = await createMode();
+
     this.modes.set(modeClass, mode);
     this._emitterStore.backofficeSyncEmitter.emit(`mode_${name}_update`);
+    return mode;
   }
 
   public getMode(modeClass: typeof BaseMode<any, any, any>) {


### PR DESCRIPTION
Centurion and time trial modes now reset their claimed handlers back to the original assignments after the mode is quit.
<!-- Provide a general summary of your changes in the title above. -->

# Description
Currently the handlers which are claimed by either the time trial or centurion modes are put to unassigned after those modes end. The mode system now remembers which handlers were assigned and resets them upon release. 

Also fixes an edge case where a user tries to start a second instance of the same mode while one is ongoing deleting the new session instead of the old one.

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

#277 

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- New feature _(non-breaking change which adds functionality)_