### PR TITLE
feat: update GEWIS poster service to correspond to new website API

### DIFF
--- a/apps/aurora-client/src/handlers/poster/components/Carousel.tsx
+++ b/apps/aurora-client/src/handlers/poster/components/Carousel.tsx
@@ -49,7 +49,12 @@ export default function PosterCarousel({ posters, currentPoster, setTitle }: Pro
         );
       case 'photo':
         return (
-          <PhotoPoster key={poster.name} poster={poster} visible={visible} setTitle={setTitle} />
+          <PhotoPoster
+            key={poster.name}
+            poster={poster}
+            visible={index === currentPoster}
+            setTitle={setTitle}
+          />
         );
       case 'borrel-logo':
         return <BorrelLogoPoster key={poster.name} />;

--- a/apps/aurora-client/src/handlers/poster/types/ImagePoster.tsx
+++ b/apps/aurora-client/src/handlers/poster/types/ImagePoster.tsx
@@ -1,10 +1,12 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 interface Props {
   source: string | string[];
 }
 
 export default function ImagePoster({ source }: Props) {
+  const [failed, setFailed] = useState(false);
+
   const sourceUrl = useMemo(() => {
     if ((Array.isArray(source) && source.length === 0) || source === '') {
       return '/base/avico-stuk.png';
@@ -15,15 +17,29 @@ export default function ImagePoster({ source }: Props) {
     return source;
   }, [source]);
 
+  useEffect(() => {
+    setFailed(false);
+
+    const image = new Image();
+    image.onerror = () => setFailed(true);
+    image.src = sourceUrl;
+
+    return () => {
+      image.onerror = null;
+    };
+  }, [sourceUrl]);
+
+  const displayUrl = failed ? '/base/avico-stuk.png' : sourceUrl;
+
   return (
     <div className="w-full h-full bg-black relative">
       <div
         className="absolute w-full h-full opacity-50 z-20 bg-no-repeat bg-cover bg-center"
-        style={{ backgroundImage: `url("${sourceUrl}")`, filter: 'blur(1vh)' }}
+        style={{ backgroundImage: `url("${displayUrl}")`, filter: 'blur(1vh)' }}
       ></div>
       <div
         className="object-contain block relative z-30 h-full bg-no-repeat bg-contain bg-center"
-        style={{ backgroundImage: `url("${sourceUrl}")` }}
+        style={{ backgroundImage: `url("${displayUrl}")` }}
       />
     </div>
   );

--- a/apps/aurora-core/integration-test/modules/carousel-poster.spec.ts
+++ b/apps/aurora-core/integration-test/modules/carousel-poster.spec.ts
@@ -1,4 +1,4 @@
-import { describe, beforeAll, it, expect, vi } from 'vitest';
+import { describe, beforeAll, afterEach, it, expect, vi } from 'vitest';
 import axios, { AxiosError, type AxiosResponse } from 'axios';
 import { TestEnvironment, type TestApp } from '../shared/test-app';
 import { expectApiError, expectValidationError } from '../shared/response-matchers';
@@ -7,6 +7,10 @@ let testApp: TestApp;
 
 beforeAll(async () => {
   testApp = await TestEnvironment.getInstance().getTestApp();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 /**
@@ -260,6 +264,101 @@ describe('POST /api/handler/screen/poster/carousel/photo', () => {
 
     // ASSERT
     expect(res.status).toBe(403);
+    axiosSpy.mockRestore();
+  });
+
+  it('returns a poster URL served by aurora, not by GEWIS', async () => {
+    // ARRANGE
+    const axiosSpy = vi.spyOn(axios, 'get').mockImplementation(async (url: string) => {
+      if (url.includes('/photos?page=')) return { data: { data: [{ id: 42 }] } } as AxiosResponse;
+      return { data: { data: { name: 'Bata 2025' } } } as AxiosResponse;
+    });
+
+    // ACT
+    const res = await testApp.authorizedAgent
+      .post('/api/handler/screen/poster/carousel/photo')
+      .send({ albumIds: [7] });
+
+    // ASSERT
+    expect(res.status).toBe(200);
+    expect(res.body.label).toBe('Bata 2025');
+    expect(res.body.url).toBe('/api/handler/screen/poster/carousel/photo/42');
+    axiosSpy.mockRestore();
+  });
+});
+
+describe('GET /api/handler/screen/poster/carousel/photo/{photoId}', () => {
+  const rendition = Buffer.from('webp-bytes');
+
+  function renditionResponse(): AxiosResponse {
+    return { data: rendition, headers: { 'content-type': 'image/webp' } } as AxiosResponse;
+  }
+
+  function renditionPending(): AxiosError {
+    const rejection = new AxiosError('Service Unavailable');
+    rejection.response = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'retry-after': '1' },
+    } as unknown as AxiosResponse;
+    return rejection;
+  }
+
+  it('returns 401 without auth', async () => {
+    // ACT
+    const res = await testApp.unauthorizedAgent.get('/api/handler/screen/poster/carousel/photo/42');
+
+    // ASSERT
+    expectApiError(res, 401);
+  });
+
+  it('serves the rendition of the requested photo', async () => {
+    // ARRANGE
+    const axiosSpy = vi.spyOn(axios, 'get').mockResolvedValue(renditionResponse());
+
+    // ACT
+    const res = await testApp.authorizedAgent.get('/api/handler/screen/poster/carousel/photo/42');
+
+    // ASSERT
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toBe('image/webp');
+    expect(Buffer.from(res.body)).toEqual(rendition);
+    expect(axiosSpy.mock.calls.map((call) => call[0])).toEqual([
+      'https://gewis.nl/api/photos/42/image/w1920',
+    ]);
+    axiosSpy.mockRestore();
+  });
+
+  it('retries the same photo until the rendition is generated', async () => {
+    // ARRANGE
+    const axiosSpy = vi
+      .spyOn(axios, 'get')
+      .mockRejectedValueOnce(renditionPending())
+      .mockResolvedValueOnce(renditionResponse());
+
+    // ACT
+    const res = await testApp.authorizedAgent.get('/api/handler/screen/poster/carousel/photo/42');
+
+    // ASSERT
+    expect(res.status).toBe(200);
+    expect(Buffer.from(res.body)).toEqual(rendition);
+    expect(axiosSpy.mock.calls.map((call) => call[0])).toEqual([
+      'https://gewis.nl/api/photos/42/image/w1920',
+      'https://gewis.nl/api/photos/42/image/w1920',
+    ]);
+    axiosSpy.mockRestore();
+  });
+
+  it('returns 503 when the rendition is never generated', async () => {
+    // ARRANGE
+    const axiosSpy = vi.spyOn(axios, 'get').mockRejectedValue(renditionPending());
+
+    // ACT
+    const res = await testApp.authorizedAgent.get('/api/handler/screen/poster/carousel/photo/42');
+
+    // ASSERT
+    expect(res.status).toBe(503);
+    expect(axiosSpy).toHaveBeenCalledTimes(3);
     axiosSpy.mockRestore();
   });
 });

--- a/apps/aurora-core/src/modules/handlers/screen/poster/carousel-poster-controller.ts
+++ b/apps/aurora-core/src/modules/handlers/screen/poster/carousel-poster-controller.ts
@@ -145,6 +145,19 @@ export class CarouselPosterController extends Controller {
   }
 
   @Security(SecurityNames.LOCAL, securityGroups.poster.base)
+  @Get('photo/{photoId}')
+  public async getPhotoImage(photoId: number, @Request() request: ExpressRequest): Promise<void> {
+    const { buffer, contentType } = await new GEWISPosterService().getPhotoImage(photoId);
+
+    const res = request.res;
+    if (!res) return;
+
+    res.setHeader('Content-Type', contentType);
+    res.setHeader('Cache-Control', 'public, max-age=86400');
+    res.send(buffer);
+  }
+
+  @Security(SecurityNames.LOCAL, securityGroups.poster.base)
   @Get('olympics/medal-table')
   public async getOlympicsMedalTable(): Promise<MedalTableRecord[]> {
     return new OlympicsService().getMedalTable();

--- a/apps/aurora-core/src/modules/handlers/screen/poster/gewis-poster-service.ts
+++ b/apps/aurora-core/src/modules/handlers/screen/poster/gewis-poster-service.ts
@@ -1,5 +1,5 @@
-import axios, { AxiosError } from 'axios';
-import { HttpApiException } from '../../../../helpers/custom-error';
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { HttpApiException, HttpStatusCode } from '../../../../helpers/custom-error';
 
 export interface GEWISPhotoAlbumParams {
   albumIds: number[];
@@ -10,26 +10,59 @@ export interface PhotoResponse {
   url: string;
 }
 
+export interface PhotoImage {
+  buffer: Buffer;
+  contentType: string;
+}
+
+const GEWIS_PHOTOS_API = 'https://gewis.nl/api/photos';
+
+const PHOTO_VARIANT = 'w1920';
+const MAX_RENDITION_ATTEMPTS = 3;
+const RENDITION_RETRY_MS = 1000;
+const MAX_RENDITION_WAIT_MS = 3000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export default class GEWISPosterService {
-  public async getPhoto(params: GEWISPhotoAlbumParams): Promise<PhotoResponse> {
-    const config = {
+  private config(config?: AxiosRequestConfig): AxiosRequestConfig {
+    return {
+      ...config,
       headers: {
-        'X-Auth-Token': process.env.GEWIS_KEY,
+        Authorization: `Bearer ${process.env.GEWIS_KEY}`,
+        'X-Api-Version': '5.0.0',
       },
     };
+  }
 
-    const chosenAlbumIndex = Math.floor(Math.random() * params.albumIds.length);
-    const albumId = params.albumIds[chosenAlbumIndex];
+  private async randomPhotoId(albumId: number): Promise<number> {
+    const photos: { id: number }[] = (
+      await axios.get(
+        `${GEWIS_PHOTOS_API}/albums/${albumId}/photos?page=1&itemsPerPage=500`,
+        this.config(),
+      )
+    ).data.data;
+
+    if (photos.length === 0) {
+      throw new HttpApiException(HttpStatusCode.NotFound, `Album ${albumId} contains no photos`);
+    }
+
+    return photos[Math.floor(Math.random() * photos.length)].id;
+  }
+
+  public async getPhoto(params: GEWISPhotoAlbumParams): Promise<PhotoResponse> {
+    const albumId = params.albumIds[Math.floor(Math.random() * params.albumIds.length)];
 
     try {
-      const returnObj = (await axios.get(`https://gewis.nl/api/photo/album/${albumId}`, config))
+      const photoId = await this.randomPhotoId(albumId);
+      const album = (await axios.get(`${GEWIS_PHOTOS_API}/albums/${albumId}`, this.config())).data
         .data;
-      const nrOfPhotos = returnObj.photos.length;
-      const photo = returnObj.photos[Math.floor(Math.random() * nrOfPhotos)];
 
       return {
-        label: returnObj.album.name,
-        url: `https://gewis.nl/data/${photo.path}`,
+        label: album.name,
+        url: `/api/handler/screen/poster/carousel/photo/${photoId}`,
       };
     } catch (e) {
       if (e instanceof AxiosError && e.response?.status && e.response.status < 500) {
@@ -37,5 +70,43 @@ export default class GEWISPosterService {
       }
       throw e;
     }
+  }
+
+  /*
+  The retry loop is temporary while the generation of photo renditions is running. This will become
+  obsolete but harmless later.
+   */
+  public async getPhotoImage(photoId: number): Promise<PhotoImage> {
+    for (let attempt = 0; attempt < MAX_RENDITION_ATTEMPTS; attempt++) {
+      try {
+        const response = await axios.get(
+          `${GEWIS_PHOTOS_API}/${photoId}/image/${PHOTO_VARIANT}`,
+          this.config({ responseType: 'arraybuffer' }),
+        );
+
+        return {
+          buffer: Buffer.from(response.data),
+          contentType: (response.headers['content-type'] as string) ?? 'application/octet-stream',
+        };
+      } catch (e) {
+        if (e instanceof AxiosError && e.response?.status === HttpStatusCode.ServiceUnavailable) {
+          if (attempt === MAX_RENDITION_ATTEMPTS - 1) break;
+
+          // Retry is bounded by MAX_WAIT as the API changing this number to a large amount would
+          // mess things up.
+          const retryAfter = Number(e.response.headers?.['retry-after']) * 1000;
+          await sleep(
+            retryAfter ? Math.min(retryAfter, MAX_RENDITION_WAIT_MS) : RENDITION_RETRY_MS,
+          );
+          continue;
+        }
+        if (e instanceof AxiosError && e.response?.status && e.response.status < 500) {
+          throw new HttpApiException(e.response.status, e.response.statusText);
+        }
+        throw e;
+      }
+    }
+
+    throw new HttpApiException(HttpStatusCode.ServiceUnavailable);
   }
 }

--- a/libs/aurora-api-client/openapi.json
+++ b/libs/aurora-api-client/openapi.json
@@ -10331,6 +10331,45 @@
 				}
 			}
 		},
+		"/handler/screen/poster/carousel/photo/{photoId}": {
+			"get": {
+				"operationId": "GetPhotoImage",
+				"responses": {
+					"204": {
+						"description": "No content"
+					}
+				},
+				"tags": [
+					"Handlers"
+				],
+				"security": [
+					{
+						"local": [
+							"admin",
+							"board",
+							"avico",
+							"bac",
+							"key-holder",
+							"audio-subscriber",
+							"screen-subscriber",
+							"lights-subscriber",
+							"integration-user"
+						]
+					}
+				],
+				"parameters": [
+					{
+						"in": "path",
+						"name": "photoId",
+						"required": true,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
 		"/handler/screen/poster/carousel/olympics/medal-table": {
 			"get": {
 				"operationId": "GetOlympicsMedalTable",


### PR DESCRIPTION
Fix GEWIS photo posters to work with the changed GEWIS website photo API

# Description

Migrating to GEWISWEBNG broke the GEWIS poster service because some API endpoints changed and the API now no longer exposes the images unauthenticated. Now the new endpoints are used and aurora core functions as a buffer between the website and the clients by passing a new endpoint uri in the request instead of the GEWIS.nl img link directly.

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_