### PR TITLE
fix: broken content type verification for progressbar logo

### DIFF
--- a/apps/aurora-core/src/modules/handlers/screen/poster/base-poster-screen-controller.ts
+++ b/apps/aurora-core/src/modules/handlers/screen/poster/base-poster-screen-controller.ts
@@ -6,7 +6,7 @@ import { ServerSettingsStore } from '../../../server-settings';
 import { ISettings } from '../../../server-settings/server-setting';
 import { SecurityNames } from '../../../../helpers/security';
 import { securityGroups } from '../../../../helpers/security-groups';
-import { fromBuffer } from 'file-type';
+import { lookup } from 'mime-types';
 
 export interface PosterScreenSettingsResponse {
   defaultMinimal: boolean;
@@ -61,10 +61,10 @@ export class BasePosterScreenController extends Controller {
     const res = request?.res;
     if (logo && res) {
       const buffer = await fileStorage.getFile(logo);
-      const fileType = await fromBuffer(buffer);
-      const contentType = fileType?.mime ?? 'application/octet-stream';
+      const contentType = lookup(logo.originalName) || 'application/octet-stream';
 
-      res.setHeader('Content-Disposition', 'attachment; filename=' + logo.originalName);
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Disposition', 'inline; filename=' + logo.originalName);
       res.setHeader('Content-Type', contentType);
       res.send(buffer);
     }
@@ -87,10 +87,10 @@ export class BasePosterScreenController extends Controller {
     const res = request?.res;
     if (stylesheet && res) {
       const buffer = await fileStorage.getFile(stylesheet);
-      const fileType = await fromBuffer(buffer);
-      const contentType = fileType?.mime ?? 'application/octet-stream';
+      const contentType = lookup(stylesheet.originalName) || 'application/octet-stream';
 
-      res.setHeader('Content-Disposition', 'attachment; filename=' + stylesheet.originalName);
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.setHeader('Content-Disposition', 'inline; filename=' + stylesheet.originalName);
       res.setHeader('Content-Type', contentType);
       res.send(buffer);
     }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->
Removed mime-type checking from progressbar logo and custom css stylesheet because it was broken.

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

The progressbar logo has been silently broken for a while but went unnoticed because of caching. The file type checking is now reverted to how it was before.

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_