### PR TITLE
fix: scalar .Count crash in pc-usage-agent under strict mode

### DIFF
--- a/tools/pc-usage-agent/Send-PcUsage.ps1
+++ b/tools/pc-usage-agent/Send-PcUsage.ps1
@@ -191,7 +191,7 @@ function Get-Sessions {
 
         # ">console  jdoe  2  Active  ..." — the leading > marks the current
         # session and is not part of the name.
-        $fields = ($line -replace '^\s*>', '') -split '\s+' | Where-Object { $_ -ne '' }
+        $fields = @(($line -replace '^\s*>', '') -split '\s+' | Where-Object { $_ -ne '' })
         if ($fields.Count -lt 3) { continue }
 
         $sessionName = $fields[0]
@@ -291,7 +291,7 @@ if (-not [string]::IsNullOrWhiteSpace($VirtualDesktopHost)) {
     } elseif (-not (Test-Online -ComputerName $VirtualDesktopHost)) {
         $report.Add(@{ pcId = 'vdesktop'; status = 'offline' })
     } else {
-        $sessions = Get-Sessions -ComputerName $VirtualDesktopHost
+        $sessions = @(Get-Sessions -ComputerName $VirtualDesktopHost)
         if ($sessions.Count -eq 0) {
             # Still report the machine, so an empty vdesktop reads as free
             # rather than going stale into offline.


### PR DESCRIPTION
Get-Sessions returns a 1-element array, which PowerShell unwraps to a scalar object; on Windows PowerShell 5.1 with Set-StrictMode -Version Latest, .Count on that scalar throws when the vdesktop has exactly one active session. Wrap the session list and the qwinsta field parse in @() so both are always arrays.

<!-- Provide a general summary of your changes in the title above. -->

# Description

<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
When making changes to the UI, make sure to include comparison screenshots!
-->

## Related issues/external references

<!--
Format issues on GitHub as `#XXX`. Tickets from support.gewis.nl can also be auto-linked by using
`ABC-YYMM-XXX`.
-->

## Types of changes

<!-- What types of changes does your code introduce? Remove all the items that do not apply: -->

- Bug fix _(non-breaking change which fixes an issue)_
- New feature _(non-breaking change which adds functionality)_
- Breaking change _(fix or feature that would cause existing functionality to change)_
- Documentation improvement
- Style _(Change that do not affect the functionality of the code)_
- CI/CD _(Changes to the CI/CD configuration)_
