### PR TITLE
feat: improve design of workspace widget

### DIFF
--- a/apps/aurora-client/src/handlers/info/components/PcUsageMap.tsx
+++ b/apps/aurora-client/src/handlers/info/components/PcUsageMap.tsx
@@ -99,7 +99,6 @@ function SvgIcon({
 
 export default function PcUsageMap({ pcs, settings }: Props) {
   const pcStyle = sStr(settings, 'pcStyle', 'circle');
-  const showNames = sBool(settings, 'showUsernames', true);
   const showVdesktops = sBool(settings, 'showVdesktops', true);
 
   const byId = new Map(pcs.map((pc) => [pc.pcId, pc]));
@@ -115,7 +114,7 @@ export default function PcUsageMap({ pcs, settings }: Props) {
     <svg
       viewBox="0 0 830 350"
       preserveAspectRatio="xMidYMid meet"
-      className="h-full w-full font-raleway"
+      className="h-full w-full font-lato"
     >
       {/* Room outline, ported from the legacy map_room.svg. */}
       <g fill="none" stroke="rgba(255,255,255,0.4)" strokeWidth="2" strokeLinecap="round">
@@ -147,7 +146,7 @@ export default function PcUsageMap({ pcs, settings }: Props) {
 
         const showNumber = text === id;
         const name = user?.name ?? '';
-        const labelY = node.labelAbove ? node.y - R - 6 : node.y + R + 20;
+        const labelY = node.labelAbove ? node.y - R - 12 : node.y + R + 28;
 
         return (
           <g key={id}>
@@ -201,7 +200,7 @@ export default function PcUsageMap({ pcs, settings }: Props) {
             ) : (
               <text
                 x={node.x}
-                y={pcStyle === 'icon' ? node.y - 1 : node.y + 1}
+                y={pcStyle === 'icon' ? node.y - R * 0.25 + 2 : node.y}
                 textAnchor="middle"
                 dominantBaseline="central"
                 fontSize={showNumber ? 18 : 20}

--- a/apps/aurora-client/src/handlers/info/components/PcUsageMap.tsx
+++ b/apps/aurora-client/src/handlers/info/components/PcUsageMap.tsx
@@ -99,6 +99,7 @@ function SvgIcon({
 
 export default function PcUsageMap({ pcs, settings }: Props) {
   const pcStyle = sStr(settings, 'pcStyle', 'circle');
+  const showNames = sBool(settings, 'showUsernames', true);
   const showVdesktops = sBool(settings, 'showVdesktops', true);
 
   const byId = new Map(pcs.map((pc) => [pc.pcId, pc]));


### PR DESCRIPTION
Improve some spacing and font of the workspaces widget of the infoscreen.

# Description

I was looking at the infoscreen, and found that the numbers in the computers were not centered. Also, they used a weird font that made them impossible to center, as not all characters were centered the same. Furthermore, the names are on the line, but they would look better with some margin to the line. 
So, i set out to fix it. And there we are. 

## Types of changes

- Style _(Change that do not affect the functionality of the code)_

